### PR TITLE
feat: GitHub 문서 수집 Batch 스케줄러 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,4 +36,5 @@ out/
 ### VS Code ###
 .vscode/
 .env
-.env.prod
+.env.prod.omc/
+.omc/

--- a/.omc/project-memory.json
+++ b/.omc/project-memory.json
@@ -1,0 +1,137 @@
+{
+  "version": "1.0.0",
+  "lastScanned": 1775228206687,
+  "projectRoot": "/Users/ukongee/Downloads/backend",
+  "techStack": {
+    "languages": [
+      {
+        "name": "Java/Kotlin",
+        "version": null,
+        "confidence": "high",
+        "markers": [
+          "build.gradle"
+        ]
+      }
+    ],
+    "frameworks": [],
+    "packageManager": "gradle",
+    "runtime": null
+  },
+  "build": {
+    "buildCommand": null,
+    "testCommand": null,
+    "lintCommand": null,
+    "devCommand": null,
+    "scripts": {}
+  },
+  "conventions": {
+    "namingStyle": null,
+    "importStyle": null,
+    "testPattern": null,
+    "fileOrganization": null
+  },
+  "structure": {
+    "isMonorepo": false,
+    "workspaces": [],
+    "mainDirectories": [
+      "src"
+    ],
+    "gitBranches": null
+  },
+  "customNotes": [],
+  "directoryMap": {
+    "build": {
+      "path": "build",
+      "purpose": "Build output",
+      "fileCount": 1,
+      "lastAccessed": 1775228206682,
+      "keyFiles": [
+        "resolvedMainClassName"
+      ]
+    },
+    "gradle": {
+      "path": "gradle",
+      "purpose": null,
+      "fileCount": 0,
+      "lastAccessed": 1775228206682,
+      "keyFiles": []
+    },
+    "src": {
+      "path": "src",
+      "purpose": "Source code",
+      "fileCount": 0,
+      "lastAccessed": 1775228206683,
+      "keyFiles": []
+    },
+    "src/test": {
+      "path": "src/test",
+      "purpose": "Test files",
+      "fileCount": 0,
+      "lastAccessed": 1775228206683,
+      "keyFiles": []
+    }
+  },
+  "hotPaths": [
+    {
+      "path": "src/main/java/gitgalaxy/backend/service/RepoCollectorService.java",
+      "accessCount": 3,
+      "lastAccessed": 1775786683008,
+      "type": "file"
+    },
+    {
+      "path": "src/main/java/gitgalaxy/backend/config/JacksonConfig.java",
+      "accessCount": 2,
+      "lastAccessed": 1775786648375,
+      "type": "file"
+    },
+    {
+      "path": "src/main/java/gitgalaxy/backend/model/ChunkDocument.java",
+      "accessCount": 2,
+      "lastAccessed": 1775786750975,
+      "type": "file"
+    },
+    {
+      "path": "src/main/java/gitgalaxy/backend/model/RepoInput.java",
+      "accessCount": 2,
+      "lastAccessed": 1775786791359,
+      "type": "file"
+    },
+    {
+      "path": ".env.example",
+      "accessCount": 1,
+      "lastAccessed": 1775784701704,
+      "type": "file"
+    },
+    {
+      "path": "src/main/resources/application-dev.properties",
+      "accessCount": 1,
+      "lastAccessed": 1775785674134,
+      "type": "file"
+    },
+    {
+      "path": "compose.yml",
+      "accessCount": 1,
+      "lastAccessed": 1775785674361,
+      "type": "file"
+    },
+    {
+      "path": "src/main/resources/application.properties",
+      "accessCount": 1,
+      "lastAccessed": 1775786647454,
+      "type": "file"
+    },
+    {
+      "path": "src/main/java/gitgalaxy/backend/service/GithubClient.java",
+      "accessCount": 1,
+      "lastAccessed": 1775786655417,
+      "type": "file"
+    },
+    {
+      "path": "src/main/java/gitgalaxy/backend/service/StorageService.java",
+      "accessCount": 1,
+      "lastAccessed": 1775786656639,
+      "type": "file"
+    }
+  ],
+  "userDirectives": []
+}

--- a/.omc/sessions/9ed14bc9-3feb-4f57-ae89-0ffd75b4d0ba.json
+++ b/.omc/sessions/9ed14bc9-3feb-4f57-ae89-0ffd75b4d0ba.json
@@ -1,0 +1,8 @@
+{
+  "session_id": "9ed14bc9-3feb-4f57-ae89-0ffd75b4d0ba",
+  "ended_at": "2026-04-03T15:01:42.374Z",
+  "reason": "other",
+  "agents_spawned": 0,
+  "agents_completed": 0,
+  "modes_used": []
+}

--- a/.omc/state/hud-state.json
+++ b/.omc/state/hud-state.json
@@ -1,0 +1,6 @@
+{
+  "timestamp": "2026-04-10T01:28:55.873Z",
+  "backgroundTasks": [],
+  "sessionStartTimestamp": "2026-04-10T01:17:58.553Z",
+  "sessionId": "fca4c8526a4d8c0f"
+}

--- a/.omc/state/last-tool-error.json
+++ b/.omc/state/last-tool-error.json
@@ -1,0 +1,7 @@
+{
+  "tool_name": "Bash",
+  "tool_input_preview": "{\"command\":\"git push origin main\",\"description\":\"Push to origin main\"}",
+  "error": "Exit code 128\nremote: Repository not found.\nfatal: repository 'https://github.com/2026-teecher-team-b/backend.git/' not found",
+  "timestamp": "2026-04-03T15:06:01.230Z",
+  "retry_count": 1
+}

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
-	compileOnly 'org.projectlombok:lombok'
+compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 
 	runtimeOnly 'org.postgresql:postgresql'

--- a/repos.json
+++ b/repos.json
@@ -1,0 +1,6 @@
+[
+  {"owner": "spring-projects", "repo": "spring-framework"},
+  {"owner": "spring-projects", "repo": "spring-boot"},
+  {"owner": "langchain-ai",    "repo": "langchain"},
+  {"owner": "openai",          "repo": "openai-cookbook"}
+]

--- a/src/main/java/gitgalaxy/backend/BackendApplication.java
+++ b/src/main/java/gitgalaxy/backend/BackendApplication.java
@@ -2,8 +2,10 @@ package gitgalaxy.backend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class BackendApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/gitgalaxy/backend/batch/RepoBatchJob.java
+++ b/src/main/java/gitgalaxy/backend/batch/RepoBatchJob.java
@@ -1,0 +1,65 @@
+package gitgalaxy.backend.batch;
+
+import gitgalaxy.backend.config.GithubCollectorProperties;
+import gitgalaxy.backend.model.RepoResult;
+import gitgalaxy.backend.service.RepoCollectorService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+/**
+ * 스케줄러 기반 Batch Job 진입점.
+ *
+ * - cron 표현식은 application.properties의 github.collector.cron-expression 으로 설정
+ * - 기본값: "0 0 * * * *" (매 시각 정각)
+ * - 멀티스레드 없이 단일 스레드로 순차 실행 (추후 @Async 또는 ThreadPoolTaskExecutor로 확장 가능)
+ *
+ * cron 예시:
+ *   "0 0 * * * *"       1시간마다
+ *   "0 0 9 * * *"       매일 오전 9시
+ *   "0 0 0/6 * * *"     6시간마다
+ *   "0 0/30 * * * *"    30분마다
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class RepoBatchJob {
+
+    private final RepoCollectorService repoCollectorService;
+    private final GithubCollectorProperties props;
+
+    @Scheduled(cron = "${github.collector.cron-expression:0 0 * * * *}")
+    public void run() {
+        // GitHub Token 미설정 시 조기 종료
+        if (props.getToken() == null || props.getToken().isBlank()) {
+            log.error("GITHUB_TOKEN 환경변수가 설정되지 않았습니다. Batch Job을 건너뜁니다.");
+            return;
+        }
+
+        log.info("╔═══════════════════════════════════════╗");
+        log.info("║   GitHub Doc Collector Batch 시작      ║");
+        log.info("╚═══════════════════════════════════════╝");
+        long jobStart = System.currentTimeMillis();
+
+        try {
+            List<RepoResult> results = repoCollectorService.runBatch();
+
+            long success = results.stream().filter(r -> "success".equals(r.getStatus())).count();
+            long failed  = results.stream().filter(r -> "failed".equals(r.getStatus())).count();
+            long skipped = results.stream().filter(r -> "skipped".equals(r.getStatus())).count();
+            long elapsed = System.currentTimeMillis() - jobStart;
+
+            log.info("╔═══════════════════════════════════════╗");
+            log.info("║   Batch 완료                           ║");
+            log.info("║   total={} success={} failed={} skipped={}", results.size(), success, failed, skipped);
+            log.info("║   elapsed={}ms", elapsed);
+            log.info("╚═══════════════════════════════════════╝");
+
+        } catch (Exception e) {
+            log.error("Batch Job에서 예상치 못한 오류 발생", e);
+        }
+    }
+}

--- a/src/main/java/gitgalaxy/backend/config/GithubCollectorProperties.java
+++ b/src/main/java/gitgalaxy/backend/config/GithubCollectorProperties.java
@@ -1,0 +1,32 @@
+package gitgalaxy.backend.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties(prefix = "github.collector")
+@Data
+public class GithubCollectorProperties {
+
+    /** GitHub Personal Access Token (환경변수 GITHUB_TOKEN 으로 주입) */
+    private String token = "";
+
+    /** repo 목록 파일 경로 (.json 또는 .csv) */
+    private String repoListPath = "repos.json";
+
+    /** JSONL 출력 디렉토리 */
+    private String outputDir = "output";
+
+    /** 이미 수집된 repo skip 여부 */
+    private boolean skipExisting = true;
+
+    /** 최대 재시도 횟수 */
+    private int maxRetries = 3;
+
+    /** 첫 번째 재시도 대기 시간 (ms), 이후 exponential backoff */
+    private long retryDelayMs = 1000;
+
+    /** Spring cron 표현식 (기본: 1시간마다) */
+    private String cronExpression = "0 0 * * * *";
+}

--- a/src/main/java/gitgalaxy/backend/config/JacksonConfig.java
+++ b/src/main/java/gitgalaxy/backend/config/JacksonConfig.java
@@ -1,0 +1,6 @@
+package gitgalaxy.backend.config;
+
+// Spring Boot 4 (Jackson 3)의 JacksonAutoConfiguration이 ObjectMapper를 자동 구성합니다.
+// 별도 설정이 필요한 경우 이 클래스에 @Configuration + @Bean 을 추가하세요.
+public class JacksonConfig {
+}

--- a/src/main/java/gitgalaxy/backend/model/ChunkDocument.java
+++ b/src/main/java/gitgalaxy/backend/model/ChunkDocument.java
@@ -1,0 +1,36 @@
+package gitgalaxy.backend.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Data;
+
+/**
+ * 문서 파일의 heading 단위 청크 (JSONL 한 줄 = 하나의 ChunkDocument)
+ */
+@Data
+@Builder
+public class ChunkDocument {
+
+    @JsonProperty("repo_owner")
+    private String repoOwner;
+
+    @JsonProperty("repo_name")
+    private String repoName;
+
+    @JsonProperty("file_path")
+    private String filePath;
+
+    @JsonProperty("chunk_id")
+    private String chunkId;
+
+    @JsonProperty("chunk_index")
+    private int chunkIndex;
+
+    /** 속한 heading 텍스트 (없으면 "(intro)") */
+    private String heading;
+
+    private String content;
+
+    /** GitHub 파일 URL */
+    private String url;
+}

--- a/src/main/java/gitgalaxy/backend/model/RepoInput.java
+++ b/src/main/java/gitgalaxy/backend/model/RepoInput.java
@@ -1,0 +1,15 @@
+package gitgalaxy.backend.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * repos.json / repos.csv 에서 읽어들이는 수집 대상 repo 정보
+ */
+public record RepoInput(
+        @JsonProperty("owner") String owner,
+        @JsonProperty("repo") String repo
+) {
+    public String fullName() {
+        return owner + "/" + repo;
+    }
+}

--- a/src/main/java/gitgalaxy/backend/model/RepoResult.java
+++ b/src/main/java/gitgalaxy/backend/model/RepoResult.java
@@ -1,0 +1,33 @@
+package gitgalaxy.backend.model;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+/**
+ * repo 단위 수집 결과 (batch_summary에 기록됨)
+ */
+@Data
+@Builder
+public class RepoResult {
+
+    private String owner;
+    private String repo;
+
+    /** success | failed | skipped */
+    private String status;
+
+    private int fileCount;
+    private int chunkCount;
+    private long durationMs;
+
+    /** 실패 시 에러 메시지 */
+    private String errorMessage;
+
+    private LocalDateTime processedAt;
+
+    public String fullName() {
+        return owner + "/" + repo;
+    }
+}

--- a/src/main/java/gitgalaxy/backend/service/ChunkingService.java
+++ b/src/main/java/gitgalaxy/backend/service/ChunkingService.java
@@ -1,0 +1,132 @@
+package gitgalaxy.backend.service;
+
+import gitgalaxy.backend.model.ChunkDocument;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Markdown/RST 문서를 heading 기준으로 chunk로 분할.
+ *
+ * - h1~h6 heading 경계에서 분할
+ * - 하나의 section이 MAX_CHUNK_CHARS를 초과하면 단락(\n\n) 기준으로 추가 분할
+ * - chunk_id: {owner}_{repo}_{file_path}_{index} (특수문자 → _)
+ */
+@Service
+@Slf4j
+public class ChunkingService {
+
+    /** Markdown heading 라인 패턴: # ~ ###### 로 시작하는 줄 */
+    private static final Pattern HEADING_LINE = Pattern.compile("^(#{1,6})\\s+(.+)$");
+
+    /** chunk 최대 문자 수 (초과 시 단락 기준 재분할) */
+    private static final int MAX_CHUNK_CHARS = 2000;
+
+    // ────────────────────────────────────────────────
+
+    public List<ChunkDocument> chunk(String content, String owner, String repo,
+                                     String filePath, String fileUrl) {
+        if (content == null || content.isBlank()) return List.of();
+
+        List<String[]> sections = splitByHeadings(content); // [heading, body]
+        List<ChunkDocument> chunks = new ArrayList<>();
+
+        for (String[] section : sections) {
+            String heading = section[0];
+            String body = section[1];
+
+            for (String part : splitIfTooLarge(body)) {
+                String trimmed = part.strip();
+                if (trimmed.isBlank()) continue;
+
+                int idx = chunks.size();
+                chunks.add(ChunkDocument.builder()
+                        .repoOwner(owner)
+                        .repoName(repo)
+                        .filePath(filePath)
+                        .chunkId(buildChunkId(owner, repo, filePath, idx))
+                        .chunkIndex(idx)
+                        .heading(heading.isBlank() ? "(intro)" : heading)
+                        .content(trimmed)
+                        .url(fileUrl)
+                        .build());
+            }
+        }
+
+        return chunks;
+    }
+
+    // ────────────────────────────────────────────────
+    // Private helpers
+    // ────────────────────────────────────────────────
+
+    /**
+     * 문서를 heading 경계 기준으로 [heading, body] 쌍의 리스트로 분할.
+     * heading 이전의 intro 내용은 heading=""로 처리.
+     */
+    private List<String[]> splitByHeadings(String content) {
+        List<String[]> sections = new ArrayList<>();
+        String[] lines = content.split("\n");
+
+        StringBuilder body = new StringBuilder();
+        String currentHeading = "";
+
+        for (String line : lines) {
+            Matcher m = HEADING_LINE.matcher(line);
+            if (m.matches()) {
+                // 현재까지 쌓인 내용 저장
+                String accumulated = body.toString().strip();
+                if (!accumulated.isBlank() || !currentHeading.isBlank()) {
+                    sections.add(new String[]{currentHeading, accumulated});
+                }
+                currentHeading = m.group(2).strip();
+                body = new StringBuilder();
+            } else {
+                body.append(line).append("\n");
+            }
+        }
+
+        // 마지막 section
+        String lastBody = body.toString().strip();
+        sections.add(new String[]{currentHeading, lastBody});
+
+        return sections.stream()
+                .filter(s -> !s[1].isBlank())
+                .toList();
+    }
+
+    /**
+     * section body가 MAX_CHUNK_CHARS를 초과하면 빈 줄(\n\n) 기준으로 추가 분할.
+     */
+    private List<String> splitIfTooLarge(String text) {
+        if (text.length() <= MAX_CHUNK_CHARS) return List.of(text);
+
+        List<String> result = new ArrayList<>();
+        String[] paragraphs = text.split("\n\n+");
+        StringBuilder current = new StringBuilder();
+
+        for (String para : paragraphs) {
+            boolean willExceed = current.length() > 0
+                    && current.length() + para.length() + 2 > MAX_CHUNK_CHARS;
+            if (willExceed) {
+                result.add(current.toString().strip());
+                current = new StringBuilder();
+            }
+            if (!current.isEmpty()) current.append("\n\n");
+            current.append(para);
+        }
+        if (!current.isEmpty()) result.add(current.toString().strip());
+
+        return result.isEmpty() ? List.of(text) : result;
+    }
+
+    private String buildChunkId(String owner, String repo, String filePath, int idx) {
+        return (owner + "_" + repo + "_" + filePath + "_" + idx)
+                .replaceAll("[^a-zA-Z0-9_-]", "_")
+                .replaceAll("_+", "_");
+    }
+}

--- a/src/main/java/gitgalaxy/backend/service/FileSelector.java
+++ b/src/main/java/gitgalaxy/backend/service/FileSelector.java
@@ -1,0 +1,109 @@
+package gitgalaxy.backend.service;
+
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * GitHub repo tree에서 문서 파일만 필터링.
+ *
+ * 포함 기준:
+ *   - 루트의 README.md, *.md, *.rst
+ *   - docs/, doc/, documentation/
+ *   - examples/, example/
+ *   - guides/, guide/, tutorial/, tutorials/, wiki/
+ *
+ * 제외 기준:
+ *   - CHANGELOG, LICENSE, CONTRIBUTING 등 메타 파일
+ *   - test/, tests/, node_modules/, .github/, build/, dist/
+ *   - 숨김 디렉토리(.으로 시작)
+ */
+@Service
+public class FileSelector {
+
+    private static final Set<String> EXCLUDED_FILENAMES = Set.of(
+            "changelog.md", "changes.md", "history.md", "license.md",
+            "licence.md", "contributing.md", "code_of_conduct.md",
+            "security.md", "authors.md", "maintainers.md",
+            "codeowners", "funding.yml"
+    );
+
+    private static final List<String> INCLUDED_DIR_PREFIXES = List.of(
+            "docs/", "doc/", "documentation/",
+            "examples/", "example/",
+            "guides/", "guide/",
+            "tutorial/", "tutorials/",
+            "wiki/"
+    );
+
+    private static final List<String> EXCLUDED_DIR_PREFIXES = List.of(
+            "node_modules/", "vendor/", "build/", "dist/",
+            ".github/", ".git/"
+    );
+
+    private static final List<String> EXCLUDED_DIR_CONTAINS = List.of(
+            "/node_modules/", "/vendor/", "/test/", "/tests/",
+            "/spec/", "/__tests__/", "/build/", "/dist/"
+    );
+
+    private static final Set<String> INCLUDED_EXTENSIONS = Set.of(".md", ".mdx", ".rst");
+
+    // ────────────────────────────────────────────────
+
+    public List<String> filterDocFiles(List<String> paths) {
+        return paths.stream()
+                .filter(this::isDocumentFile)
+                .collect(Collectors.toList());
+    }
+
+    public boolean isDocumentFile(String path) {
+        if (path == null || path.isBlank()) return false;
+
+        String lower = path.toLowerCase();
+
+        // 제외: 숨김 디렉토리
+        if (lower.startsWith(".") || lower.contains("/.")) return false;
+
+        // 제외: 알려진 비문서 디렉토리 prefix
+        for (String excluded : EXCLUDED_DIR_PREFIXES) {
+            if (lower.startsWith(excluded)) return false;
+        }
+
+        // 제외: 경로 중간에 있는 비문서 디렉토리
+        for (String excluded : EXCLUDED_DIR_CONTAINS) {
+            if (lower.contains(excluded)) return false;
+        }
+
+        // 확장자 체크
+        String ext = getExtension(lower);
+        if (!INCLUDED_EXTENSIONS.contains(ext)) return false;
+
+        // 제외 파일명 체크
+        String filename = getFilename(lower);
+        if (EXCLUDED_FILENAMES.contains(filename)) return false;
+
+        // 루트 레벨 파일 (경로에 / 없음) → 허용
+        if (!path.contains("/")) return true;
+
+        // 허용된 디렉토리 prefix
+        for (String included : INCLUDED_DIR_PREFIXES) {
+            if (lower.startsWith(included)) return true;
+        }
+
+        return false;
+    }
+
+    private String getExtension(String path) {
+        int dot = path.lastIndexOf('.');
+        if (dot < 0) return "";
+        int slash = path.lastIndexOf('/');
+        return dot > slash ? path.substring(dot) : "";
+    }
+
+    private String getFilename(String path) {
+        int slash = path.lastIndexOf('/');
+        return slash >= 0 ? path.substring(slash + 1) : path;
+    }
+}

--- a/src/main/java/gitgalaxy/backend/service/GithubClient.java
+++ b/src/main/java/gitgalaxy/backend/service/GithubClient.java
@@ -1,0 +1,195 @@
+package gitgalaxy.backend.service;
+
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import gitgalaxy.backend.config.GithubCollectorProperties;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * GitHub API / raw content 호출 담당.
+ * - java.net.http.HttpClient 사용 (응답 헤더 직접 접근 가능)
+ * - 3회 retry + exponential backoff
+ * - rate limit(403/429) 감지 시 X-RateLimit-Reset 기준으로 sleep
+ */
+@Service
+@Slf4j
+public class GithubClient {
+
+    private static final String API_BASE = "https://api.github.com";
+    private static final String RAW_BASE = "https://raw.githubusercontent.com";
+
+    private final HttpClient httpClient;
+    private final ObjectMapper objectMapper;
+    private final GithubCollectorProperties props;
+
+    public GithubClient(ObjectMapper objectMapper, GithubCollectorProperties props) {
+        this.objectMapper = objectMapper;
+        this.props = props;
+        this.httpClient = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(30))
+                .build();
+    }
+
+    // ────────────────────────────────────────────────
+    // Public API
+    // ────────────────────────────────────────────────
+
+    /** repo의 default branch 이름 반환 */
+    public String getDefaultBranch(String owner, String repo) {
+        String url = API_BASE + "/repos/" + owner + "/" + repo;
+        String body = executeApiGet(url);
+        try {
+            return objectMapper.readTree(body).get("default_branch").asText();
+        } catch (Exception e) {
+            throw new RuntimeException("default_branch 파싱 실패: " + url, e);
+        }
+    }
+
+    /** recursive tree 조회 → blob 파일 경로 목록 반환 */
+    public List<String> getRepoTree(String owner, String repo, String branch) {
+        String url = API_BASE + "/repos/" + owner + "/" + repo + "/git/trees/" + branch + "?recursive=1";
+        String body = executeApiGet(url);
+        try {
+            JsonNode tree = objectMapper.readTree(body).get("tree");
+            List<String> paths = new ArrayList<>();
+            if (tree != null && tree.isArray()) {
+                for (JsonNode item : tree) {
+                    if ("blob".equals(item.path("type").asText())) {
+                        paths.add(item.path("path").asText());
+                    }
+                }
+            }
+            return paths;
+        } catch (Exception e) {
+            throw new RuntimeException("tree 파싱 실패: " + url, e);
+        }
+    }
+
+    /** raw 파일 내용 다운로드 */
+    public String getRawContent(String owner, String repo, String branch, String filePath) {
+        // filePath에 공백/특수문자가 있을 경우 URL encode 필요할 수 있으나 대부분의 docs는 안전
+        String url = RAW_BASE + "/" + owner + "/" + repo + "/" + branch + "/" + filePath;
+        return executeRawGet(url);
+    }
+
+    // ────────────────────────────────────────────────
+    // Internal HTTP execution
+    // ────────────────────────────────────────────────
+
+    private String executeApiGet(String url) {
+        return executeWithRetry(() -> {
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(url))
+                    .header("Authorization", "Bearer " + props.getToken())
+                    .header("Accept", "application/vnd.github+json")
+                    .header("X-GitHub-Api-Version", "2022-11-28")
+                    .timeout(Duration.ofSeconds(30))
+                    .GET()
+                    .build();
+
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+
+            // 성공 시 rate limit 잔여량 확인 → 소진 직전이면 선제 sleep
+            if (response.statusCode() == 200) {
+                proactiveRateLimitSleep(response);
+                return response.body();
+            }
+
+            // rate limit 초과
+            if (response.statusCode() == 403 || response.statusCode() == 429) {
+                long sleepMs = getRateLimitSleepMs(response);
+                log.warn("Rate limited (HTTP {}). {}ms 대기 후 재시도...", response.statusCode(), sleepMs);
+                Thread.sleep(sleepMs);
+                throw new RuntimeException("Rate limited: HTTP " + response.statusCode());
+            }
+
+            throw new RuntimeException("GitHub API 오류: HTTP " + response.statusCode() + " → " + url);
+        });
+    }
+
+    private String executeRawGet(String url) {
+        return executeWithRetry(() -> {
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(url))
+                    .timeout(Duration.ofSeconds(30))
+                    .GET()
+                    .build();
+
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+
+            if (response.statusCode() >= 400) {
+                throw new RuntimeException("Raw content 오류: HTTP " + response.statusCode() + " → " + url);
+            }
+            return response.body();
+        });
+    }
+
+    // ────────────────────────────────────────────────
+    // Retry & Rate limit helpers
+    // ────────────────────────────────────────────────
+
+    @FunctionalInterface
+    private interface CheckedSupplier<T> {
+        T get() throws Exception;
+    }
+
+    private <T> T executeWithRetry(CheckedSupplier<T> supplier) {
+        Exception lastException = null;
+        for (int attempt = 0; attempt < props.getMaxRetries(); attempt++) {
+            try {
+                return supplier.get();
+            } catch (InterruptedException ie) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException("Interrupted during retry", ie);
+            } catch (Exception e) {
+                lastException = e;
+                if (attempt < props.getMaxRetries() - 1) {
+                    long delay = props.getRetryDelayMs() * (1L << attempt); // 1s → 2s → 4s
+                    log.warn("시도 {}/{} 실패 ({}). {}ms 후 재시도...",
+                            attempt + 1, props.getMaxRetries(), e.getMessage(), delay);
+                    try {
+                        Thread.sleep(delay);
+                    } catch (InterruptedException ie) {
+                        Thread.currentThread().interrupt();
+                        throw new RuntimeException("Interrupted during retry wait", ie);
+                    }
+                }
+            }
+        }
+        throw new RuntimeException("최대 재시도(" + props.getMaxRetries() + "회) 초과", lastException);
+    }
+
+    /** 성공 응답에서 X-RateLimit-Remaining 이 낮으면 reset 시간까지 선제 sleep */
+    private void proactiveRateLimitSleep(HttpResponse<String> response) {
+        response.headers().firstValue("X-RateLimit-Remaining").ifPresent(remaining -> {
+            if (Integer.parseInt(remaining) <= 5) {
+                long sleepMs = getRateLimitSleepMs(response);
+                log.warn("Rate limit 잔여량={}. Reset까지 {}ms 선제 대기...", remaining, sleepMs);
+                try {
+                    Thread.sleep(sleepMs);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+        });
+    }
+
+    /** X-RateLimit-Reset 헤더 기반 sleep 시간 계산 (없으면 기본 60초) */
+    private long getRateLimitSleepMs(HttpResponse<String> response) {
+        return response.headers().firstValue("X-RateLimit-Reset")
+                .map(reset -> {
+                    long resetMs = Long.parseLong(reset) * 1000L;
+                    return Math.max(1000L, resetMs - System.currentTimeMillis() + 1000L);
+                })
+                .orElse(60_000L);
+    }
+}

--- a/src/main/java/gitgalaxy/backend/service/RepoCollectorService.java
+++ b/src/main/java/gitgalaxy/backend/service/RepoCollectorService.java
@@ -1,0 +1,201 @@
+package gitgalaxy.backend.service;
+
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.ObjectMapper;
+import gitgalaxy.backend.config.GithubCollectorProperties;
+import gitgalaxy.backend.model.ChunkDocument;
+import gitgalaxy.backend.model.RepoInput;
+import gitgalaxy.backend.model.RepoResult;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 전체 수집 흐름 조율 (Orchestrator).
+ *
+ * 흐름:
+ *   1. repo 목록 로드 (JSON / CSV)
+ *   2. 각 repo 순차 처리:
+ *      - skip 여부 확인
+ *      - default branch 조회
+ *      - tree recursive 조회
+ *      - 문서 파일 필터링
+ *      - 파일별 raw content 다운로드 + chunking
+ *      - JSONL 저장
+ *   3. batch_summary 저장
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class RepoCollectorService {
+
+    private final GithubCollectorProperties props;
+    private final GithubClient githubClient;
+    private final FileSelector fileSelector;
+    private final ChunkingService chunkingService;
+    private final StorageService storageService;
+    private final ObjectMapper objectMapper;
+
+    // ────────────────────────────────────────────────
+    // Batch entry
+    // ────────────────────────────────────────────────
+
+    public List<RepoResult> runBatch() {
+        List<RepoInput> repos = loadRepoList();
+        if (repos.isEmpty()) {
+            log.warn("처리할 repo가 없습니다. repo 목록 파일 확인: {}", props.getRepoListPath());
+            return List.of();
+        }
+
+        log.info("=== Batch 시작: {}개 repo 처리 ===", repos.size());
+        List<RepoResult> results = new ArrayList<>();
+
+        for (int i = 0; i < repos.size(); i++) {
+            RepoInput input = repos.get(i);
+            RepoResult result = collectRepo(input);
+            results.add(result);
+            log.info("[{}/{}] {} → status={}, files={}, chunks={}, {}ms",
+                    i + 1, repos.size(),
+                    input.fullName(),
+                    result.getStatus(),
+                    result.getFileCount(),
+                    result.getChunkCount(),
+                    result.getDurationMs());
+        }
+
+        storageService.saveBatchSummary(results);
+        return results;
+    }
+
+    // ────────────────────────────────────────────────
+    // Repo 단위 수집 (fail isolation)
+    // ────────────────────────────────────────────────
+
+    public RepoResult collectRepo(RepoInput input) {
+        long start = System.currentTimeMillis();
+
+        // ── skip 판단 ──
+        if (props.isSkipExisting() && storageService.isAlreadyCollected(input.owner(), input.repo())) {
+            log.info("SKIP (이미 수집됨): {}", input.fullName());
+            return RepoResult.builder()
+                    .owner(input.owner()).repo(input.repo())
+                    .status("skipped")
+                    .durationMs(elapsed(start))
+                    .processedAt(LocalDateTime.now())
+                    .build();
+        }
+
+        try {
+            // ── default branch 조회 ──
+            String branch = githubClient.getDefaultBranch(input.owner(), input.repo());
+            log.debug("{}: default branch = {}", input.fullName(), branch);
+
+            // ── tree recursive 조회 ──
+            List<String> allPaths = githubClient.getRepoTree(input.owner(), input.repo(), branch);
+
+            // ── 문서 파일 필터링 ──
+            List<String> docPaths = fileSelector.filterDocFiles(allPaths);
+            log.info("{}: 문서 파일 {}개 선택 (전체 {}개)", input.fullName(), docPaths.size(), allPaths.size());
+
+            // ── 파일별 다운로드 & chunking ──
+            List<ChunkDocument> allChunks = new ArrayList<>();
+            for (String filePath : docPaths) {
+                try {
+                    String content = githubClient.getRawContent(input.owner(), input.repo(), branch, filePath);
+                    String fileUrl = buildGithubUrl(input.owner(), input.repo(), branch, filePath);
+                    List<ChunkDocument> chunks = chunkingService.chunk(
+                            content, input.owner(), input.repo(), filePath, fileUrl);
+                    allChunks.addAll(chunks);
+                } catch (Exception e) {
+                    // 파일 단위 실패 → 경고만 남기고 계속 진행
+                    log.warn("{}/{}: 파일 처리 실패 → {}", input.fullName(), filePath, e.getMessage());
+                }
+            }
+
+            // ── JSONL 저장 ──
+            storageService.saveChunks(input.owner(), input.repo(), allChunks);
+
+            return RepoResult.builder()
+                    .owner(input.owner()).repo(input.repo())
+                    .status("success")
+                    .fileCount(docPaths.size())
+                    .chunkCount(allChunks.size())
+                    .durationMs(elapsed(start))
+                    .processedAt(LocalDateTime.now())
+                    .build();
+
+        } catch (Exception e) {
+            log.error("{}: 수집 실패 → {}", input.fullName(), e.getMessage(), e);
+            return RepoResult.builder()
+                    .owner(input.owner()).repo(input.repo())
+                    .status("failed")
+                    .errorMessage(e.getMessage())
+                    .durationMs(elapsed(start))
+                    .processedAt(LocalDateTime.now())
+                    .build();
+        }
+    }
+
+    // ────────────────────────────────────────────────
+    // Repo 목록 로드
+    // ────────────────────────────────────────────────
+
+    public List<RepoInput> loadRepoList() {
+        String pathStr = props.getRepoListPath();
+        Path filePath = Path.of(pathStr);
+
+        if (!Files.exists(filePath)) {
+            log.warn("repo 목록 파일을 찾을 수 없습니다: {}", filePath.toAbsolutePath());
+            return List.of();
+        }
+
+        try {
+            if (pathStr.endsWith(".json")) {
+                return objectMapper.readValue(filePath.toFile(), new TypeReference<List<RepoInput>>() {});
+            } else if (pathStr.endsWith(".csv")) {
+                return loadFromCsv(filePath);
+            } else {
+                log.error("지원하지 않는 repo 목록 형식입니다 (json/csv만 지원): {}", pathStr);
+                return List.of();
+            }
+        } catch (IOException e) {
+            log.error("repo 목록 로드 실패: {}", e.getMessage(), e);
+            return List.of();
+        }
+    }
+
+    private List<RepoInput> loadFromCsv(Path filePath) throws IOException {
+        List<RepoInput> repos = new ArrayList<>();
+        try (BufferedReader reader = Files.newBufferedReader(filePath, StandardCharsets.UTF_8)) {
+            reader.readLine(); // header skip
+            String line;
+            while ((line = reader.readLine()) != null) {
+                if (line.isBlank()) continue;
+                String[] parts = line.split(",");
+                if (parts.length >= 2) {
+                    repos.add(new RepoInput(parts[0].strip(), parts[1].strip()));
+                }
+            }
+        }
+        return repos;
+    }
+
+    // ────────────────────────────────────────────────
+
+    private long elapsed(long startMs) {
+        return System.currentTimeMillis() - startMs;
+    }
+
+    private String buildGithubUrl(String owner, String repo, String branch, String filePath) {
+        return "https://github.com/" + owner + "/" + repo + "/blob/" + branch + "/" + filePath;
+    }
+}

--- a/src/main/java/gitgalaxy/backend/service/StorageService.java
+++ b/src/main/java/gitgalaxy/backend/service/StorageService.java
@@ -1,0 +1,120 @@
+package gitgalaxy.backend.service;
+
+import tools.jackson.databind.ObjectMapper;
+import gitgalaxy.backend.config.GithubCollectorProperties;
+import gitgalaxy.backend.model.ChunkDocument;
+import gitgalaxy.backend.model.RepoResult;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+/**
+ * JSONL 저장 / batch_summary.json·csv 작성 / skip 판단 담당.
+ *
+ * 출력 구조:
+ *   {outputDir}/{owner}/{repo}/chunks.jsonl
+ *   {outputDir}/batch_summary.json
+ *   {outputDir}/batch_summary.csv
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class StorageService {
+
+    private final GithubCollectorProperties props;
+    private final ObjectMapper objectMapper;
+
+    // ────────────────────────────────────────────────
+    // Skip 판단
+    // ────────────────────────────────────────────────
+
+    /**
+     * 이미 수집된 repo인지 확인 (chunks.jsonl 존재 + 비어있지 않으면 수집 완료로 간주)
+     */
+    public boolean isAlreadyCollected(String owner, String repo) {
+        Path jsonlFile = repoDir(owner, repo).resolve("chunks.jsonl");
+        return Files.exists(jsonlFile) && jsonlFile.toFile().length() > 0;
+    }
+
+    // ────────────────────────────────────────────────
+    // JSONL 저장
+    // ────────────────────────────────────────────────
+
+    public void saveChunks(String owner, String repo, List<ChunkDocument> chunks) throws IOException {
+        Path dir = repoDir(owner, repo);
+        Files.createDirectories(dir);
+
+        Path jsonlFile = dir.resolve("chunks.jsonl");
+        try (BufferedWriter writer = Files.newBufferedWriter(jsonlFile, StandardCharsets.UTF_8)) {
+            for (ChunkDocument chunk : chunks) {
+                writer.write(objectMapper.writeValueAsString(chunk));
+                writer.newLine();
+            }
+        }
+        log.info("[{}] chunks.jsonl 저장 완료: {} 청크", owner + "/" + repo, chunks.size());
+    }
+
+    // ────────────────────────────────────────────────
+    // Batch 요약 저장
+    // ────────────────────────────────────────────────
+
+    public void saveBatchSummary(List<RepoResult> results) {
+        Path outDir = Path.of(props.getOutputDir());
+        try {
+            Files.createDirectories(outDir);
+            writeJson(outDir.resolve("batch_summary.json"), results);
+            writeCsv(outDir.resolve("batch_summary.csv"), results);
+            log.info("batch_summary 저장 완료 → {}", outDir.toAbsolutePath());
+        } catch (IOException e) {
+            log.error("batch_summary 저장 실패", e);
+        }
+    }
+
+    // ────────────────────────────────────────────────
+    // Private helpers
+    // ────────────────────────────────────────────────
+
+    private void writeJson(Path file, List<RepoResult> results) throws IOException {
+        objectMapper.writerWithDefaultPrettyPrinter().writeValue(file.toFile(), results);
+    }
+
+    private void writeCsv(Path file, List<RepoResult> results) throws IOException {
+        try (BufferedWriter w = Files.newBufferedWriter(file, StandardCharsets.UTF_8)) {
+            w.write("owner,repo,status,file_count,chunk_count,duration_ms,error_message,processed_at");
+            w.newLine();
+            for (RepoResult r : results) {
+                w.write(String.join(",",
+                        csv(r.getOwner()),
+                        csv(r.getRepo()),
+                        csv(r.getStatus()),
+                        String.valueOf(r.getFileCount()),
+                        String.valueOf(r.getChunkCount()),
+                        String.valueOf(r.getDurationMs()),
+                        csv(r.getErrorMessage()),
+                        csv(r.getProcessedAt() != null ? r.getProcessedAt().toString() : "")
+                ));
+                w.newLine();
+            }
+        }
+    }
+
+    /** null 안전 + 쉼표/줄바꿈 포함 시 큰따옴표로 감싸기 */
+    private String csv(String value) {
+        if (value == null) return "";
+        if (value.contains(",") || value.contains("\"") || value.contains("\n")) {
+            return "\"" + value.replace("\"", "\"\"") + "\"";
+        }
+        return value;
+    }
+
+    private Path repoDir(String owner, String repo) {
+        return Path.of(props.getOutputDir(), owner, repo);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,3 +9,26 @@ spring.datasource.driver-class-name=org.postgresql.Driver
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
+
+# ─── GitHub Doc Collector ───────────────────────────────
+# GITHUB_TOKEN 환경변수로 주입 (미설정 시 batch job skip)
+github.collector.token=${GITHUB_TOKEN:}
+
+# repo 목록 파일 경로 (프로젝트 루트 기준, .json 또는 .csv)
+github.collector.repo-list-path=repos.json
+
+# JSONL 출력 디렉토리
+github.collector.output-dir=output
+
+# 이미 수집된 repo skip
+github.collector.skip-existing=true
+
+# 재시도 횟수 / 첫 대기시간(ms) → exponential backoff
+github.collector.max-retries=3
+github.collector.retry-delay-ms=1000
+
+# cron 표현식 (Spring 형식: 초 분 시 일 월 요일)
+# 0 0 * * * *     → 매 시각 정각 (1시간마다)
+# 0 0 9 * * *     → 매일 오전 9시
+# 0 0 */6 * * *   → 6시간마다
+github.collector.cron-expression=0 0 * * * *


### PR DESCRIPTION
## Summary
- GitHub API 기반 repo 문서 수집 파이프라인을 Spring Boot Batch 시스템으로 구현
- `@Scheduled` cron 기반 자동 실행 (기본: 1시간마다)
- repo 단위 fail isolation, retry + exponential backoff, rate limit 대응

## 추가된 구조
```
batch/RepoBatchJob.java           스케줄러 진입점 (@Scheduled)
config/GithubCollectorProperties  application.properties 바인딩
model/RepoInput, RepoResult, ChunkDocument
service/GithubClient              GitHub API 호출 (retry, rate limit)
service/FileSelector              문서 파일 필터링
service/ChunkingService           heading 기반 chunk 분할
service/RepoCollectorService      전체 흐름 조율
service/StorageService            JSONL / batch_summary 저장
```

## 주요 기능
- [ ] repos.json / repos.csv 에서 수집 대상 목록 로드
- [ ] repo tree recursive 조회 → 문서 파일 필터링
- [ ] heading 기반 chunking → output/{owner}/{repo}/chunks.jsonl 저장
- [ ] skip-existing: 이미 수집된 repo 건너뜀
- [ ] 3회 retry + exponential backoff (1s → 2s → 4s)
- [ ] rate limit 감지 시 X-RateLimit-Reset 기준 sleep
- [ ] batch_summary.json / batch_summary.csv 결과 기록

## 설정
```properties
github.collector.token=${GITHUB_TOKEN}
github.collector.repo-list-path=repos.json
github.collector.cron-expression=0 0 * * * *
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)