### PR TITLE
ai 요약 재사용 감소, 레포 가져올때 생성

### DIFF
--- a/src/main/java/gitgalaxy/backend/service/AiSummerize.java
+++ b/src/main/java/gitgalaxy/backend/service/AiSummerize.java
@@ -11,6 +11,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.util.Optional;
+
 @Service
 @Slf4j
 @RequiredArgsConstructor
@@ -24,6 +26,12 @@ public class AiSummerize {
     private final GithubClient githubClient;
 
     public String summarize(String owner, String repo) {
+        Optional<RepoAiSummary> existing = repoAiSummaryRepository.findByOwnerAndRepo(owner, repo);
+        if (existing.isPresent() && existing.get().getSummary() != null) {
+            log.debug("[{}/{}] 기존 요약 재사용", owner, repo);
+            return existing.get().getSummary();
+        }
+
         String readme = fetchReadme(owner, repo);
         if (readme == null || readme.isBlank()) {
             log.warn("[{}/{}] README 없음 — 요약 생략", owner, repo);

--- a/src/main/java/gitgalaxy/backend/service/TrendingRssService.java
+++ b/src/main/java/gitgalaxy/backend/service/TrendingRssService.java
@@ -38,6 +38,7 @@ public class TrendingRssService {
     private final ChunkingService chunkingService;
     private final GithubClient githubClient;
     private final RepoSaveService repoSaveService;
+    private final AiSummerize aiSummerize;
     private final HttpClient httpClient = HttpClient.newHttpClient();
 
     /**
@@ -72,6 +73,13 @@ public class TrendingRssService {
                 gitgalaxy.backend.model.RepoMeta meta = githubClient.getRepoMeta(owner, name);
                 repoSaveService.saveOrUpdate(owner, name, meta);
                 upserted++;
+
+                // 신규 레포만 LLM 요약 (기존 레포는 DB에서 재사용)
+                try {
+                    aiSummerize.summarize(owner, name);
+                } catch (Exception e) {
+                    log.warn("[{}/{}] 요약 실패 (스킵): {}", owner, name, e.getMessage());
+                }
 
                 // README fetch → chunk
                 List<ChunkDocument> chunks = fetchReadmeChunks(owner, name);


### PR DESCRIPTION
## 📌 관련 이슈
- 

## ✨ 작업 내용
- 레포 문서 요약 하는거 trendingrss로 레포 들고올때 한번 하고 그 이후로 db에서 꺼내서 쓰기.
중복 레포일때 llm 재생성 방지

## 📸 스크린샷 (선택)
## 📚 체크리스트
- [ ] 브랜치 전략(Git Flow 등)을 잘 지켰나요?
- [ ] 커밋 메시지 컨벤션을 준수했나요?
- [ ] 테스트 코드를 작성했거나 로컬에서 충분히 테스트했나요?
- [ ] 불필요한 주석이나 console.log는 삭제했나요?
