### PR TITLE
feat: pgvector HNSW 인덱스 적용 및 Hybrid RAG 검색 파이프라인 구축

### DIFF
--- a/src/main/java/gitgalaxy/backend/repository/ChunkEmbeddingRepository.java
+++ b/src/main/java/gitgalaxy/backend/repository/ChunkEmbeddingRepository.java
@@ -75,4 +75,17 @@ public class ChunkEmbeddingRepository {
                 """,
                 queryVector, queryVector, limit);
     }
+
+    /** Hybrid 검색용: Dense Top-N + embedded_at 반환 (재랭킹은 서비스 레이어에서 수행) */
+    public List<Map<String, Object>> findSimilarGlobalWithTime(String queryVector, int limit) {
+        return jdbc.queryForList("""
+                SELECT chunk_id, repo_owner, repo_name, file_path, heading, content, url,
+                       1 - (embedding <=> ?::vector) AS similarity,
+                       embedded_at
+                FROM chunk_embeddings
+                ORDER BY embedding <=> ?::vector
+                LIMIT ?
+                """,
+                queryVector, queryVector, limit);
+    }
 }

--- a/src/main/java/gitgalaxy/backend/service/RagService.java
+++ b/src/main/java/gitgalaxy/backend/service/RagService.java
@@ -5,8 +5,9 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
-import java.util.List;
-import java.util.Map;
+import java.sql.Timestamp;
+import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * RAG 파이프라인: 질문 → 벡터 검색 → context 구성 → LLM 설명 생성.
@@ -23,10 +24,19 @@ import java.util.Map;
 public class RagService {
 
     private static final int TOP_K = 5;
+    private static final int CANDIDATE_MULTIPLIER = 4; // Hybrid용 후보 배수
+
+    // Hybrid 가중치: dense 70%, time 30% (intent에 따라 time 가중치 조정)
+    private static final double W_DENSE = 0.7;
+    private static final double W_TIME_LATEST = 0.5;  // 최신 intent: time 가중치 증가
+    private static final double W_TIME_STABLE = 0.1;  // 안정적 intent: time 가중치 감소
+    private static final double W_TIME_NEUTRAL = 0.3;
 
     private final EmbeddingService embeddingService;
     private final ChunkEmbeddingRepository chunkEmbeddingRepository;
     private final LlmService llmService;
+
+    enum QueryIntent { LATEST, STABLE, NEUTRAL }
 
     /** 특정 repo에 대한 질문 답변 */
     public String explain(String owner, String repo, String question) {
@@ -43,21 +53,92 @@ public class RagService {
         return llmService.chat(buildPrompt(owner + "/" + repo, question, buildContext(chunks)));
     }
 
-    /** 전체 repo 대상 글로벌 검색 */
+    /** 전체 repo 대상 Hybrid RAG 검색 */
     public String explainGlobal(String question) {
+        QueryIntent intent = detectIntent(question);
+        log.debug("RAG global: 질문='{}' intent={}", question, intent);
+
         String queryVector = toQueryVector(question);
 
-        List<Map<String, Object>> chunks = chunkEmbeddingRepository.findSimilarGlobal(queryVector, TOP_K);
+        // Dense Top-N*4 후보 추출 (embedded_at 포함)
+        List<Map<String, Object>> candidates = chunkEmbeddingRepository
+                .findSimilarGlobalWithTime(queryVector, TOP_K * CANDIDATE_MULTIPLIER);
 
-        if (chunks.isEmpty()) {
+        if (candidates.isEmpty()) {
             return "수집된 문서 데이터가 없습니다. POST /admin/collect 로 수집을 먼저 실행하세요.";
         }
 
-        log.debug("RAG global: 질문='{}' → {}개 청크 검색됨", question, chunks.size());
-        return llmService.chat(buildPrompt("GitHub repos", question, buildContext(chunks)));
+        // 레포별 그룹핑 → 대표 청크 선택 → Hybrid 재랭킹
+        List<Map<String, Object>> reranked = hybridRerank(candidates, intent, TOP_K);
+
+        log.debug("RAG global: {}개 후보 → {}개 재랭킹 완료", candidates.size(), reranked.size());
+        return llmService.chat(buildPrompt("GitHub repos", question, buildContext(reranked)));
     }
 
     // ────────────────────────────────────────────────
+
+    private QueryIntent detectIntent(String question) {
+        String q = question.toLowerCase();
+        if (q.contains("최신") || q.contains("최근") || q.contains("trending") ||
+            q.contains("요즘") || q.contains("새로운") || q.contains("latest") ||
+            q.contains("new") || q.contains("recent")) {
+            return QueryIntent.LATEST;
+        }
+        if (q.contains("검증된") || q.contains("안정적") || q.contains("오래된") ||
+            q.contains("classic") || q.contains("stable") || q.contains("mature")) {
+            return QueryIntent.STABLE;
+        }
+        return QueryIntent.NEUTRAL;
+    }
+
+    private List<Map<String, Object>> hybridRerank(
+            List<Map<String, Object>> candidates, QueryIntent intent, int topK) {
+
+        // time_score 정규화를 위한 min/max 계산
+        long minTime = Long.MAX_VALUE, maxTime = Long.MIN_VALUE;
+        for (Map<String, Object> c : candidates) {
+            long t = toEpoch(c.get("embedded_at"));
+            if (t < minTime) minTime = t;
+            if (t > maxTime) maxTime = t;
+        }
+        long timeRange = maxTime - minTime;
+
+        double wTime = switch (intent) {
+            case LATEST -> W_TIME_LATEST;
+            case STABLE -> W_TIME_STABLE;
+            case NEUTRAL -> W_TIME_NEUTRAL;
+        };
+        double wDense = 1.0 - wTime;
+
+        // 레포별 그룹핑 → 각 레포에서 dense 점수 가장 높은 청크를 대표로 선택
+        Map<String, Map<String, Object>> repByRepo = new LinkedHashMap<>();
+        for (Map<String, Object> chunk : candidates) {
+            String repoKey = chunk.get("repo_owner") + "/" + chunk.get("repo_name");
+            repByRepo.merge(repoKey, chunk, (existing, incoming) -> {
+                double existScore = toDouble(existing.get("similarity"));
+                double newScore = toDouble(incoming.get("similarity"));
+                return newScore > existScore ? incoming : existing;
+            });
+        }
+
+        // 대표 청크들에 Hybrid 점수 계산 후 재랭킹
+        return repByRepo.values().stream()
+                .map(chunk -> {
+                    double denseScore = toDouble(chunk.get("similarity"));
+                    double normalizedTime = timeRange == 0 ? 0.5 :
+                            (double)(toEpoch(chunk.get("embedded_at")) - minTime) / timeRange;
+                    // STABLE intent는 오래된 것이 높은 점수
+                    double timeScore = intent == QueryIntent.STABLE ? 1.0 - normalizedTime : normalizedTime;
+                    double hybridScore = wDense * denseScore + wTime * timeScore;
+
+                    Map<String, Object> scored = new HashMap<>(chunk);
+                    scored.put("hybrid_score", hybridScore);
+                    return scored;
+                })
+                .sorted(Comparator.comparingDouble(c -> -toDouble(c.get("hybrid_score"))))
+                .limit(topK)
+                .collect(Collectors.toList());
+    }
 
     private String toQueryVector(String question) {
         float[] embedding = embeddingService.embed(question);
@@ -92,5 +173,16 @@ public class RagService {
                 - 문서에 없는 내용은 "문서에 명시되지 않았습니다"라고 하세요.
                 - 한국어로 답변하세요.
                 """.formatted(target, context, question);
+    }
+
+    private long toEpoch(Object val) {
+        if (val instanceof Timestamp ts) return ts.getTime();
+        if (val instanceof java.util.Date d) return d.getTime();
+        return 0L;
+    }
+
+    private double toDouble(Object val) {
+        if (val instanceof Number n) return n.doubleValue();
+        return 0.0;
     }
 }

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -17,3 +17,7 @@ CREATE TABLE IF NOT EXISTS chunk_embeddings (
 
 CREATE INDEX IF NOT EXISTS idx_chunk_embeddings_repo
     ON chunk_embeddings (repo_owner, repo_name);
+
+CREATE INDEX IF NOT EXISTS idx_chunk_embeddings_hnsw
+    ON chunk_embeddings USING hnsw (embedding vector_cosine_ops)
+    WITH (m = 16, ef_construction = 64);


### PR DESCRIPTION
- HNSW 인덱스 추가 (m=16, ef_construction=64) — Full Scan → ANN 탐색
- findSimilarGlobalWithTime 메서드 추가 (embedded_at 포함 반환)
- QueryIntent 감지 (LATEST/STABLE/NEUTRAL) — 쿼리 키워드 기반
- 레포별 대표 청크 선택 후 Dense + Time 가중합으로 재랭킹
- LATEST intent: time 가중치 50%, STABLE: 10%, NEUTRAL: 30%

## 📌 관련 이슈
- 

## ✨ 작업 내용
- 

## 📸 스크린샷 (선택)
## 📚 체크리스트
- [ ] 브랜치 전략(Git Flow 등)을 잘 지켰나요?
- [ ] 커밋 메시지 컨벤션을 준수했나요?
- [ ] 테스트 코드를 작성했거나 로컬에서 충분히 테스트했나요?
- [ ] 불필요한 주석이나 console.log는 삭제했나요?
