### PR TITLE
트렌드 분석 LLM 호출을 수집 파이프라인에서 분리

### DIFF
--- a/src/main/java/gitgalaxy/backend/service/ScoreService.java
+++ b/src/main/java/gitgalaxy/backend/service/ScoreService.java
@@ -56,12 +56,11 @@ public class ScoreService {
         metricsRepository.updateScores(owner, name, Timestamp.valueOf(targetBucket), activeScore, healthScore, brightnessScore, sizeScore);
         log.debug("score {}/{} @{}: active={} health={}", owner, name, targetBucket, activeScore, healthScore);
 
-        // ±20% 이상 변화 시 Redis 캐시 무효화 → 다음 요청 시 LLM 재생성
+        // 점수 변화 시 캐시만 무효화 → 다음 조회 시 TTL 기반으로 자동 재생성
         if (prevBrightnessScore != null && prevBrightnessScore > 0.1) {
             double changeRate = Math.abs(brightnessScore - prevBrightnessScore) / prevBrightnessScore * 100.0;
             if (changeRate >= 20.0) {
-                log.info("score 변화 {}% → trend reason 재생성: {}/{}", String.format("%.1f", changeRate), owner, name);
-                trendReasonService.regenerate(owner, name);
+                trendReasonService.invalidateCache(owner, name);
             }
         }
     }
@@ -110,7 +109,7 @@ public class ScoreService {
             if (prev > 0.1) {
                 double changeRate = Math.abs(brightness - prev) / prev * 100.0;
                 if (changeRate >= 20.0) {
-                    trendReasonService.regenerate(parts[0], parts[1]);
+                    trendReasonService.invalidateCache(parts[0], parts[1]);
                 }
             }
         }

--- a/src/main/java/gitgalaxy/backend/service/ScoreService.java
+++ b/src/main/java/gitgalaxy/backend/service/ScoreService.java
@@ -42,12 +42,6 @@ public class ScoreService {
             return;
         }
 
-        // 이전 brightnessScore 조회
-        Double prevBrightnessScore = metricsRepository
-                .findTopByRepoOwnerAndRepoNameOrderByBucketDesc(owner, name)
-                .map(RepoHourlyMetrics::getBrightnessScore)
-                .orElse(null);
-
         double activeScore     = calcActivityScore(owner, name, targetBucket.minusHours(24), targetBucket);
         double healthScore     = calcHealthScore(owner, name, targetBucket.minusDays(7), targetBucket);
         double sizeScore       = calcHealthScore(owner, name, targetBucket.minusDays(30), targetBucket);
@@ -56,13 +50,6 @@ public class ScoreService {
         metricsRepository.updateScores(owner, name, Timestamp.valueOf(targetBucket), activeScore, healthScore, brightnessScore, sizeScore);
         log.debug("score {}/{} @{}: active={} health={}", owner, name, targetBucket, activeScore, healthScore);
 
-        // 점수 변화 시 캐시만 무효화 → 다음 조회 시 TTL 기반으로 자동 재생성
-        if (prevBrightnessScore != null && prevBrightnessScore > 0.1) {
-            double changeRate = Math.abs(brightnessScore - prevBrightnessScore) / prevBrightnessScore * 100.0;
-            if (changeRate >= 20.0) {
-                trendReasonService.invalidateCache(owner, name);
-            }
-        }
     }
 
     /**
@@ -72,15 +59,7 @@ public class ScoreService {
     public void calculateAndSaveBatch(List<String> fullNames, LocalDateTime bucket) {
         if (fullNames.isEmpty()) return;
 
-        // ① prevBrightnessScore 한방에 조회
-        Map<String, Double> prevBrightness = batchRepository.findLatestForRepos(fullNames)
-                .stream()
-                .collect(Collectors.toMap(
-                        r -> r.getRepoOwner() + "/" + r.getRepoName(),
-                        r -> r.getBrightnessScore() != null ? r.getBrightnessScore() : 0.0
-                ));
-
-        // ② 30일치 데이터 한방에 조회 (24h / 7d / 30d 모두 커버)
+        // ① 30일치 데이터 한방에 조회 (24h / 7d / 30d 모두 커버)
         List<RepoHourlyMetrics> allRows = batchRepository.findAllForReposInRange(
                 fullNames, bucket.minusDays(30), bucket);
 
@@ -105,13 +84,6 @@ public class ScoreService {
             updates.add(new RepoMetricsBatchRepository.ScoreUpdate(
                     parts[0], parts[1], bucket, active, health, brightness, size));
 
-            double prev = prevBrightness.getOrDefault(fullName, 0.0);
-            if (prev > 0.1) {
-                double changeRate = Math.abs(brightness - prev) / prev * 100.0;
-                if (changeRate >= 20.0) {
-                    trendReasonService.invalidateCache(parts[0], parts[1]);
-                }
-            }
         }
 
         // ④ UPDATE 한방에

--- a/src/main/java/gitgalaxy/backend/service/TrendReasonService.java
+++ b/src/main/java/gitgalaxy/backend/service/TrendReasonService.java
@@ -16,6 +16,7 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -28,6 +29,7 @@ import java.util.stream.Collectors;
 public class TrendReasonService {
 
     private static final String CACHE_KEY_PREFIX = "trend:reason:";
+    private static final Duration CACHE_TTL = Duration.ofHours(1);
 
     private final RepoHourlyMetricsRepository metricsRepository;
     private final RepoTrendReasonRepository trendReasonRepository;
@@ -57,7 +59,7 @@ public class TrendReasonService {
 
         // Redis에 저장
         try {
-            redisTemplate.opsForValue().set(cacheKey, objectMapper.writeValueAsString(result));
+            redisTemplate.opsForValue().set(cacheKey, objectMapper.writeValueAsString(result), CACHE_TTL);
         } catch (Exception e) {
             log.debug("Redis 캐시 저장 실패: {}", e.getMessage());
         }


### PR DESCRIPTION
## 📌 관련 이슈
- 

## ✨ 작업 내용
- gharchive  수집 할때 점수 계산까지 같이 되고 변화 +-20% 있는 llm 레포마다 재생성 했었는데   
- trendreason redis ttl 사용해서 1시간마다 초기화 하고 사용자가 페이지 들어가면 재생성으로 변경


결론 :
- gharchive 수집 할떄 변화 하는 레포 개별로 재생성 안해도 되서 속도 향상  

## 📸 스크린샷 (선택)
## 📚 체크리스트
- [ ] 브랜치 전략(Git Flow 등)을 잘 지켰나요?
- [ ] 커밋 메시지 컨벤션을 준수했나요?
- [ ] 테스트 코드를 작성했거나 로컬에서 충분히 테스트했나요?
- [ ] 불필요한 주석이나 console.log는 삭제했나요?
