### PR TITLE
배치 임베딩 Virtual Thread 병렬 처리로 인제스트 성능 개선

### DIFF
--- a/bench/EmbeddingParallelBench.java
+++ b/bench/EmbeddingParallelBench.java
@@ -1,0 +1,74 @@
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * GitGalaxy 배치 임베딩: 순차 vs Virtual Thread 병렬 wall-clock 벤치마크.
+ *
+ * 실제 embedBatch(Vertex AI 호출)는 네트워크 I/O 대기가 지배적이므로,
+ * 그 지연을 LATENCY_MS 고정 sleep으로 모사해 파이프라인 구조만 비교한다.
+ * (프로덕션 수치는 Vertex 키로 real 파이프라인을 돌려 교체 가능)
+ *
+ * 실행: java EmbeddingParallelBench.java
+ */
+public class EmbeddingParallelBench {
+
+    static final int BATCH_SIZE = 20;
+    static final int LATENCY_MS = 400;      // 임베딩 API 배치 호출 1회당 지연(가정)
+    static final int MAX_CONCURRENCY = 8;   // 운영 코드와 동일한 동시성 상한
+
+    // 임베딩 API 호출 1회를 모사 (I/O 대기)
+    static void embedBatchStub() {
+        try { Thread.sleep(LATENCY_MS); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
+    }
+
+    // 기존: 순차 배치 처리
+    static long runSequential(int totalBatches) {
+        long t0 = System.nanoTime();
+        for (int b = 0; b < totalBatches; b++) {
+            embedBatchStub();
+        }
+        return (System.nanoTime() - t0) / 1_000_000;
+    }
+
+    // 개선: Virtual Thread 병렬 + 동시성 상한(Semaphore)
+    static long runParallel(int totalBatches) {
+        long t0 = System.nanoTime();
+        AtomicInteger done = new AtomicInteger();
+        Semaphore limiter = new Semaphore(MAX_CONCURRENCY);
+        try (ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor()) {
+            List<Future<?>> futures = new ArrayList<>(totalBatches);
+            for (int b = 0; b < totalBatches; b++) {
+                futures.add(executor.submit(() -> {
+                    limiter.acquireUninterruptibly();
+                    try { embedBatchStub(); done.incrementAndGet(); }
+                    finally { limiter.release(); }
+                }));
+            }
+            for (Future<?> f : futures) {
+                try { f.get(); } catch (Exception ignored) {}
+            }
+        }
+        return (System.nanoTime() - t0) / 1_000_000;
+    }
+
+    public static void main(String[] args) {
+        int[] chunkCounts = {200, 400, 800};
+        System.out.printf("배치당 API 지연=%dms, 배치 크기=%d, 동시성 상한=%d%n%n",
+                LATENCY_MS, BATCH_SIZE, MAX_CONCURRENCY);
+        System.out.printf("%-8s %-8s %-12s %-12s %-10s%n",
+                "청크", "배치수", "순차(ms)", "병렬(ms)", "단축률");
+        for (int chunks : chunkCounts) {
+            int totalBatches = (int) Math.ceil((double) chunks / BATCH_SIZE);
+            long seq = runSequential(totalBatches);
+            long par = runParallel(totalBatches);
+            double reduction = (1.0 - (double) par / seq) * 100.0;
+            System.out.printf("%-8d %-8d %-12d %-12d %.1f%%%n",
+                    chunks, totalBatches, seq, par, reduction);
+        }
+    }
+}

--- a/src/main/java/gitgalaxy/backend/service/EmbeddingPipelineService.java
+++ b/src/main/java/gitgalaxy/backend/service/EmbeddingPipelineService.java
@@ -6,7 +6,13 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicInteger;
 
 @Service
 @RequiredArgsConstructor
@@ -14,6 +20,13 @@ import java.util.List;
 public class EmbeddingPipelineService {
 
     private static final int BATCH_SIZE = 20;
+
+    /**
+     * 동시에 진행할 배치(=Vertex AI 호출) 상한.
+     * Virtual Thread는 배치 수만큼 만들 수 있지만, 외부 임베딩 API 레이트리밋과
+     * DB 커넥션 풀(HikariCP) 고갈을 막기 위해 실제 동시 실행은 이 값으로 제한한다.
+     */
+    private static final int MAX_CONCURRENCY = 8;
 
     private final EmbeddingService embeddingService;
     private final ChunkEmbeddingRepository chunkEmbeddingRepository;
@@ -24,33 +37,66 @@ public class EmbeddingPipelineService {
             return;
         }
 
+        // 멱등: 이미 임베딩된 청크는 건너뛰고, 실패분만 재실행 시 이어서 처리
         List<ChunkDocument> toEmbed = chunks.stream()
                 .filter(chunk -> !chunkEmbeddingRepository.existsByChunkId(chunk.getChunkId()))
                 .toList();
-
         int skipped = chunks.size() - toEmbed.size();
-        int stored = 0;
 
-        int totalBatches = (int) Math.ceil((double) toEmbed.size() / BATCH_SIZE);
-        log.info("배치 임베딩 시작: 총 {}개 청크 → {}번 API 호출 예정", toEmbed.size(), totalBatches);
-
+        // 배치 분할
+        List<List<ChunkDocument>> batches = new ArrayList<>();
         for (int i = 0; i < toEmbed.size(); i += BATCH_SIZE) {
-            List<ChunkDocument> batch = toEmbed.subList(i, Math.min(i + BATCH_SIZE, toEmbed.size()));
-            int batchNum = (i / BATCH_SIZE) + 1;
-            try {
-                List<String> texts = batch.stream().map(ChunkDocument::getContent).toList();
-                List<float[]> vectors = embeddingService.embedBatch(texts);
+            batches.add(toEmbed.subList(i, Math.min(i + BATCH_SIZE, toEmbed.size())));
+        }
+        int totalBatches = batches.size();
+        if (totalBatches == 0) {
+            log.info("임베딩 완료: 저장=0 / 스킵(기존)={} / 전체={}", skipped, chunks.size());
+            return;
+        }
+        log.info("배치 임베딩 시작(Virtual Thread 병렬, 동시 상한 {}): 총 {}개 청크 → {}번 API 호출 예정",
+                MAX_CONCURRENCY, toEmbed.size(), totalBatches);
 
-                for (int j = 0; j < batch.size(); j++) {
-                    chunkEmbeddingRepository.upsert(batch.get(j), EmbeddingService.toVectorString(vectors.get(j)));
-                    stored++;
+        AtomicInteger stored = new AtomicInteger();
+        AtomicInteger failedBatches = new AtomicInteger();
+        Semaphore limiter = new Semaphore(MAX_CONCURRENCY);
+
+        // 배치별로 경량 Virtual Thread를 할당해 I/O 대기(임베딩 API 호출)를 병렬로 겹친다.
+        try (ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor()) {
+            List<Future<?>> futures = new ArrayList<>(totalBatches);
+            for (int b = 0; b < totalBatches; b++) {
+                final int batchNum = b + 1;
+                final List<ChunkDocument> batch = batches.get(b);
+                futures.add(executor.submit(() -> {
+                    limiter.acquireUninterruptibly();
+                    try {
+                        List<String> texts = batch.stream().map(ChunkDocument::getContent).toList();
+                        List<float[]> vectors = embeddingService.embedBatch(texts);
+                        for (int j = 0; j < batch.size(); j++) {
+                            chunkEmbeddingRepository.upsert(
+                                    batch.get(j), EmbeddingService.toVectorString(vectors.get(j)));
+                            stored.incrementAndGet();
+                        }
+                        log.info("배치 {}/{} 완료 ({}개)", batchNum, totalBatches, batch.size());
+                    } catch (Exception e) {
+                        // 배치 단위 실패 격리: 한 배치가 실패해도 나머지는 계속 진행
+                        failedBatches.incrementAndGet();
+                        log.warn("배치 {}/{} 실패 (스킵): {}", batchNum, totalBatches, e.getMessage());
+                    } finally {
+                        limiter.release();
+                    }
+                }));
+            }
+            // 모든 배치 완료 대기
+            for (Future<?> f : futures) {
+                try {
+                    f.get();
+                } catch (Exception e) {
+                    log.warn("배치 작업 대기 중 오류: {}", e.getMessage());
                 }
-                log.info("배치 {}/{} 완료 ({}개)", batchNum, totalBatches, batch.size());
-            } catch (Exception e) {
-                log.warn("배치 {}/{} 실패 (스킵): {}", batchNum, totalBatches, e.getMessage());
             }
         }
 
-        log.info("임베딩 완료: 저장={} / 스킵(기존)={} / 전체={} / API 호출={}", stored, skipped, chunks.size(), totalBatches);
+        log.info("임베딩 완료: 저장={} / 스킵(기존)={} / 실패배치={} / 전체={} / API 호출={}",
+                stored.get(), skipped, failedBatches.get(), chunks.size(), totalBatches);
     }
 }

--- a/src/main/java/gitgalaxy/backend/service/EmbeddingService.java
+++ b/src/main/java/gitgalaxy/backend/service/EmbeddingService.java
@@ -25,8 +25,10 @@ public class EmbeddingService {
     private static final long RETRY_DELAY_MS = 1000;
 
     private final VertexAiProperties props;
-    private VertexAI vertexAI;
-    private PredictionServiceClient client;
+    // 배치 임베딩을 Virtual Thread로 병렬 호출하므로, 공유 gRPC 클라이언트 참조를
+    // volatile로 두고 reconnect()를 동기화해 동시 재연결 시 double-close/NPE를 방지한다.
+    private volatile VertexAI vertexAI;
+    private volatile PredictionServiceClient client;
     private String endpointName;
 
     public EmbeddingService(VertexAiProperties props) {
@@ -148,7 +150,7 @@ public class EmbeddingService {
         return vector;
     }
 
-    private void reconnect() {
+    private synchronized void reconnect() {
         log.info("gRPC 재연결 시도...");
         try {
             if (client != null) client.close();


### PR DESCRIPTION
## 배경
수천 개 청크를 임베딩 API로 변환하는 배치 작업이 `for` 루프로 **순차 처리**되어, I/O 대기 시간이 배치 수에 비례해 선형으로 누적됨. 임베딩 API 호출은 대부분 네트워크 대기(I/O 바운드)라 병렬로 겹칠 여지가 큼.

## 변경 내용
- **Virtual Thread 병렬화** (`EmbeddingPipelineService`) — 배치마다 가상 스레드(Java 21)를 할당해 병렬 호출. 순차 루프 → `newVirtualThreadPerTaskExecutor`.
- **동시성 상한** — 외부 API 레이트리밋과 DB 커넥션 풀 고갈을 막기 위해 `Semaphore(8)`로 실제 동시 실행 제한.
- **공유 gRPC 클라이언트 동시성 안전** (`EmbeddingService`) — 병렬 호출 중 `reconnect()`가 다른 스레드의 클라이언트를 닫는 레이스 방지: 클라이언트 참조 `volatile` + `reconnect()` `synchronized`.
- **안정성 유지** — 배치 단위 `try/catch` 실패 격리(한 배치 실패해도 나머지 진행), `AtomicInteger` 카운터, 시작 시 `existsByChunkId` + `ON CONFLICT` upsert로 멱등 재시도.

## 성능 (벤치마크)
`bench/EmbeddingParallelBench.java` — 임베딩 API 지연을 400ms로 고정하고 순차 vs 병렬(상한 8) wall-clock 비교.

| 청크 | 배치수 | 순차 | 병렬 | 단축률 |
|---|---|---|---|---|
| 200 | 10 | 4,036ms | 839ms | 79.2% |
| 400 | 20 | 8,076ms | 1,216ms | 84.9% |
| 800 | 40 | 16,142ms | 2,022ms | 87.5% |

> 수치는 지연 400ms 가정 벤치마크 기준으로, 실제 지연에 비례해 달라짐.

## 리뷰 포인트
- `MAX_CONCURRENCY=8`은 임시값 — 실제 Vertex 레이트리밋/HikariCP 풀 크기에 맞춰 튜닝 필요.
- 컴파일 확인 완료(`./gradlew compileJava` 통과).